### PR TITLE
fix: context menu and selection position

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,7 +28,10 @@
 
 <body>
   <div id="map"></div>
-  <div id="map2"></div>
+  <!-- test transform compatibility -->
+  <div style="transform: translateX(30px) translateY(20px);">
+    <div id="map2"></div>
+  </div>
   <script type="module" src="/src/dev.ts"></script>
 </body>
 

--- a/readme.md
+++ b/readme.md
@@ -351,7 +351,7 @@ Be aware that Mind Elixir will not observe the change of `prefers-color-scheme`.
 
 ```
 pnpm i
-npm start
+pnpm dev
 ```
 
 Test generated files with `dev.dist.ts`:

--- a/src/plugin/contextMenu.ts
+++ b/src/plugin/contextMenu.ts
@@ -2,6 +2,7 @@ import i18n from '../i18n'
 import type { Topic } from '../types/dom'
 import type { MindElixirInstance } from '../types/index'
 import { encodeHTML, isTopic } from '../utils/index'
+import dragMoveHelper from '../utils/dragMoveHelper'
 import './contextMenu.less'
 
 export default function (mind: MindElixirInstance, option: any) {
@@ -91,21 +92,36 @@ export default function (mind: MindElixirInstance, option: any) {
       }
       if (!mind.currentNodes) mind.selectNode(target)
       menuContainer.hidden = false
+
+      if (dragMoveHelper.mousedown) {
+        dragMoveHelper.mousedown = false
+      }
+
+      menuUl.style.top = ''
+      menuUl.style.bottom = ''
+      menuUl.style.left = ''
+      menuUl.style.right = ''
+      const rect = menuUl.getBoundingClientRect()
       const height = menuUl.offsetHeight
       const width = menuUl.offsetWidth
-      if (height + e.clientY > window.innerHeight) {
+
+      const relativeY = e.clientY - rect.top
+      const relativeX = e.clientX - rect.left
+
+      if (height + relativeY > window.innerHeight) {
         menuUl.style.top = ''
         menuUl.style.bottom = '0px'
       } else {
         menuUl.style.bottom = ''
-        menuUl.style.top = e.clientY + 15 + 'px'
+        menuUl.style.top = relativeY + 15 + 'px'
       }
-      if (width + e.clientX > window.innerWidth) {
+
+      if (width + relativeX > window.innerWidth) {
         menuUl.style.left = ''
         menuUl.style.right = '0px'
       } else {
         menuUl.style.right = ''
-        menuUl.style.left = e.clientX + 10 + 'px'
+        menuUl.style.left = relativeX + 10 + 'px'
       }
     }
   }

--- a/src/plugin/selection.ts
+++ b/src/plugin/selection.ts
@@ -6,7 +6,7 @@ export default function (mei: MindElixirInstance) {
   const selection = new SelectionArea({
     selectables: ['.map-container me-tpc'],
     boundaries: [mei.container],
-    container: mei.container,
+    container: 'body',
     behaviour: {
       // Scroll configuration.
       scrolling: {
@@ -28,6 +28,9 @@ export default function (mei: MindElixirInstance) {
       if (((event as MouseEvent).target as Topic).tagName === 'ME-TPC') return false
       if (((event as MouseEvent).target as HTMLElement).id === 'input-box') return false
       if (((event as MouseEvent).target as HTMLElement).className === 'circle') return false
+      const selectionAreaElement = selection.getSelectionArea()
+      selectionAreaElement.style.background = '#4f90f22d'
+      selectionAreaElement.style.border = '1px solid #4f90f2'
       return true
     })
     .on('start', ({ event }) => {

--- a/src/plugin/selection.ts
+++ b/src/plugin/selection.ts
@@ -31,6 +31,9 @@ export default function (mei: MindElixirInstance) {
       const selectionAreaElement = selection.getSelectionArea()
       selectionAreaElement.style.background = '#4f90f22d'
       selectionAreaElement.style.border = '1px solid #4f90f2'
+      if (selectionAreaElement.parentElement) {
+        selectionAreaElement.parentElement.style.zIndex = '9999'
+      }
       return true
     })
     .on('start', ({ event }) => {


### PR DESCRIPTION
This PR mainly addresses the following issues:

- Fixes issue #226, where the context menu can still be moved after being closed. This issue can be reproduced on macOS.
- Fixes issue #198, where an incorrect position calculation in the case of nested transform properties leads to a displacement of the menu.
- Resolves an issue where the selection plugin also gets displaced in the case of nested transform properties.

中文：

主要修复了这几个问题

- #226 右键菜单关闭之后可以继续移动的问题，macOS 可以复现
- #198 在 transform 嵌套情况下位置计算错误导致菜单偏移的问题 
- selection 插件在 transform 嵌套情况下也会偏移的问题