### PR TITLE
feat: add mouseSelectionButton option

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -124,6 +124,7 @@ let options = {
   locale: 'en', // [zh_CN,zh_TW,en,ja,pt,ru] waiting for PRs
   overflowHidden: false, // default false
   mainLinkStyle: 2, // [1,2] default 1
+  mouseSelectionButton: 0, // 0 for left button, 2 for right button, default 0
   contextMenuOption: {
     focus: true,
     link: true,

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,7 @@ function MindElixir(
     contextMenuOption,
     toolBar,
     keypress,
+    mouseSelectionButton,
     before,
     newTopicName,
     allowUndo,
@@ -57,6 +58,7 @@ function MindElixir(
   this.contextMenu = contextMenu === undefined ? true : contextMenu
   this.toolBar = toolBar === undefined ? true : toolBar
   this.keypress = keypress === undefined ? true : keypress
+  this.mouseSelectionButton = mouseSelectionButton || 0
   this.mobileMenu = mobileMenu || false
   // record the direction before enter focus mode, must true in focus mode, reset to null after exit focus
   this.direction = typeof direction === 'number' ? direction : 1

--- a/src/mouse.ts
+++ b/src/mouse.ts
@@ -70,18 +70,21 @@ export default function (mind: MindElixirInstance) {
     }
   })
   mind.map.addEventListener('mousedown', e => {
-    if (e.button !== 2) return
+    const mouseMoveButton = mind.mouseSelectionButton === 0 ? 2 : 0
+    if (e.button !== mouseMoveButton) return
     if ((e.target as HTMLElement).contentEditable !== 'true') {
       dragMoveHelper.moved = false
       dragMoveHelper.mousedown = true
     }
   })
   mind.map.addEventListener('mouseleave', e => {
-    if (e.button !== 2) return
+    const mouseMoveButton = mind.mouseSelectionButton === 0 ? 2 : 0
+    if (e.button !== mouseMoveButton) return
     dragMoveHelper.clear()
   })
   mind.map.addEventListener('mouseup', e => {
-    if (e.button !== 2) return
+    const mouseMoveButton = mind.mouseSelectionButton === 0 ? 2 : 0
+    if (e.button !== mouseMoveButton) return
     dragMoveHelper.clear()
   })
   mind.map.addEventListener('contextmenu', e => {

--- a/src/plugin/selection.ts
+++ b/src/plugin/selection.ts
@@ -24,7 +24,7 @@ export default function (mei: MindElixirInstance) {
     },
   })
     .on('beforestart', ({ event }) => {
-      if ((event as MouseEvent).button !== 0) return false
+      if ((event as MouseEvent).button !== mei.mouseSelectionButton) return false
       if (((event as MouseEvent).target as Topic).tagName === 'ME-TPC') return false
       if (((event as MouseEvent).target as HTMLElement).id === 'input-box') return false
       if (((event as MouseEvent).target as HTMLElement).className === 'circle') return false

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -64,6 +64,7 @@ export interface MindElixirInstance extends MindElixirMethods {
   contextMenuOption: object
   toolBar: boolean
   keypress: boolean
+  mouseSelectionButton: 0 | 2
   before: Before
   newTopicName: string
   allowUndo: boolean
@@ -116,6 +117,7 @@ export interface Options {
   contextMenuOption?: any
   toolBar?: boolean
   keypress?: boolean
+  mouseSelectionButton?: 0 | 2
   before?: Before
   newTopicName?: string
   allowUndo?: boolean


### PR DESCRIPTION
This PR adds a `mouseSelectionButton` option to control whether the left mouse button or the right mouse button is used for selection.