### PR TITLE
chore: Update script tag in readme files to use type="module" for bet…

### DIFF
--- a/readme.cn.md
+++ b/readme.cn.md
@@ -51,7 +51,7 @@ import MindElixir, { E } from 'mind-elixir'
 #### Script 标签
 
 ```html
-<script src="https://cdn.jsdelivr.net/npm/mind-elixir/dist/mind-elixir.js"></script>
+<script type="module" src="https://cdn.jsdelivr.net/npm/mind-elixir/dist/mind-elixir.js"></script>
 ```
 
 ### HTML 结构

--- a/readme.md
+++ b/readme.md
@@ -93,7 +93,7 @@ import MindElixir from 'mind-elixir'
 #### Script tag
 
 ```html
-<script src="https://cdn.jsdelivr.net/npm/mind-elixir/dist/MindElixir.js"></script>
+<script type="module" src="https://cdn.jsdelivr.net/npm/mind-elixir/dist/MindElixir.js"></script>
 ```
 
 ### Init


### PR DESCRIPTION
最近发现之前写的网页加载js失败了，查看后发现新编译的MindElixir.js直接 html 通过 <script>标签引入会报错 `Uncaught SyntaxError: export declarations may only appear at top level of a module`

下面是我修改后的代码
```html
<script type="module" src="https://cdn.jsdelivr.net/npm/mind-elixir/dist/MindElixir.js"></script>
<script type="module">
import MindElixir from "https://cdn.jsdelivr.net/npm/mind-elixir/dist/MindElixir.js";
// ...
</script>

```

