### PR TITLE
perf: Restrict drag area after canvas is scaled down

### DIFF
--- a/src/mouse.ts
+++ b/src/mouse.ts
@@ -59,7 +59,7 @@ export default function (mind: MindElixirInstance) {
   mind.map.addEventListener('mousemove', e => {
     // click trigger mousemove in windows chrome
     if ((e.target as HTMLElement).contentEditable !== 'true') {
-      dragMoveHelper.onMove(e, mind.container)
+      dragMoveHelper.onMove(e, mind)
     }
   })
   mind.map.addEventListener('mousedown', e => {

--- a/src/utils/dragMoveHelper.ts
+++ b/src/utils/dragMoveHelper.ts
@@ -1,12 +1,23 @@
+import type { MindElixirInstance } from '../types/index'
+
 export default {
   moved: false, // diffrentiate click and move
   mousedown: false,
-  onMove(e: MouseEvent, container: HTMLElement) {
+  onMove(e: MouseEvent, mind: MindElixirInstance) {
     if (this.mousedown) {
       this.moved = true
       const deltaX = e.movementX
       const deltaY = e.movementY
-      container.scrollTo(container.scrollLeft - deltaX, container.scrollTop - deltaY)
+      const { container, map, scaleVal } = mind
+      let scrollLeft = container.scrollLeft - deltaX
+      let scrollTop = container.scrollTop - deltaY
+      if (scaleVal < 1) {
+        const minScrollLeft = (container.scrollWidth - map.clientWidth * scaleVal) / 2
+        const minScrollTop = (container.scrollHeight - map.clientHeight * scaleVal) / 2
+        scrollLeft = Math.max(minScrollLeft, Math.min(container.scrollWidth - minScrollLeft, scrollLeft))
+        scrollTop = Math.max(minScrollTop, Math.min(container.scrollHeight - minScrollTop, scrollTop))
+      }
+      container.scrollTo(scrollLeft, scrollTop)
     }
   },
   clear() {

--- a/src/utils/dragMoveHelper.ts
+++ b/src/utils/dragMoveHelper.ts
@@ -14,8 +14,8 @@ export default {
       if (scaleVal < 1) {
         const minScrollLeft = (container.scrollWidth - map.clientWidth * scaleVal) / 2
         const minScrollTop = (container.scrollHeight - map.clientHeight * scaleVal) / 2
-        scrollLeft = Math.max(minScrollLeft, Math.min(container.scrollWidth - minScrollLeft, scrollLeft))
-        scrollTop = Math.max(minScrollTop, Math.min(container.scrollHeight - minScrollTop, scrollTop))
+        scrollLeft = Math.max(minScrollLeft, Math.min(container.scrollWidth - minScrollLeft - container.clientWidth, scrollLeft))
+        scrollTop = Math.max(minScrollTop, Math.min(container.scrollHeight - minScrollTop - container.clientHeight, scrollTop))
       }
       container.scrollTo(scrollLeft, scrollTop)
     }


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/7d90e993-973d-4f85-8969-4f93111b95b3)

缩小画布后，向一个方向拖拽画布会出现空白区域；
从画布边缘快速向空白区域拖拽，并在空白区域松开鼠标，没法触发 dragMoveHelper.clear() ，鼠标再次移动到画布上（并没拖拽）时会出现画布随鼠标移动。

对画布可拖拽区域进行了限制，当拖拽画布到边缘时禁止再拖拽。