### PR TITLE
feat: added a new optional parameter, alignment, to MindElixir

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -109,7 +109,7 @@ function MindElixir(
   this.linkController.appendChild(this.line1)
   this.linkController.appendChild(this.line2)
   this.linkSvgGroup = createLinkSvg('topiclinks') // storage user custom link svg
-  this.alignment = alignment === undefined ? 'root' : alignment
+  this.alignment = alignment ?? 'root'
 
   this.map.appendChild(this.nodes)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,7 @@ function MindElixir(
     generateSubBranch,
     overflowHidden,
     theme,
+    alignment,
   }: Options
 ): void {
   let ele: HTMLElement | null = null
@@ -108,6 +109,7 @@ function MindElixir(
   this.linkController.appendChild(this.line1)
   this.linkController.appendChild(this.line2)
   this.linkSvgGroup = createLinkSvg('topiclinks') // storage user custom link svg
+  this.alignment = alignment === undefined ? 'root' : alignment
 
   this.map.appendChild(this.nodes)
 

--- a/src/linkDiv.ts
+++ b/src/linkDiv.ts
@@ -23,9 +23,16 @@ const linkDiv = function (this: MindElixirInstance, mainNode?: Wrapper) {
   const pW = root.offsetWidth
   const pH = root.offsetHeight
 
+  const nodes = this.map.querySelector("me-nodes");
+  const nw = (nodes as HTMLElement).offsetWidth;
+
   // pin center
   this.nodes.style.top = `${10000 - this.nodes.offsetHeight / 2}px`
-  this.nodes.style.left = `${10000 - pL - pW / 2}px`
+  if (this.alignment === 'nodes') {
+    this.nodes.style.left = `${10000 - pL - pW / 2}px`
+  } else {
+    this.nodes.style.left = `${10000 - nw / 2}px`
+  }
 
   const mainNodeList = this.map.querySelectorAll('me-main > me-wrapper')
   this.lines.innerHTML = ''

--- a/src/linkDiv.ts
+++ b/src/linkDiv.ts
@@ -28,7 +28,7 @@ const linkDiv = function (this: MindElixirInstance, mainNode?: Wrapper) {
 
   // pin center
   this.nodes.style.top = `${10000 - this.nodes.offsetHeight / 2}px`
-  if (this.alignment === 'nodes') {
+  if (this.alignment === 'root') {
     this.nodes.style.left = `${10000 - pL - pW / 2}px`
   } else {
     this.nodes.style.left = `${10000 - nw / 2}px`

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -54,6 +54,8 @@ export type Theme = {
   }>
 }
 
+export type Aligment = 'root' | 'nodes'
+
 /**
  * The MindElixir instance
  *
@@ -125,6 +127,8 @@ export interface MindElixirInstance extends MindElixirMethods {
 
   selection: SelectionArea
   selectionContainer?: string | HTMLElement
+
+  alignment: Aligment
 }
 type PathString = string
 /**
@@ -152,6 +156,7 @@ export type Options = {
   theme?: Theme
   nodeMenu?: boolean
   selectionContainer?: string | HTMLElement
+  alignment?: Aligment
 }
 
 export type Uid = string

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -54,7 +54,7 @@ export type Theme = {
   }>
 }
 
-export type Aligment = 'root' | 'nodes'
+export type Alignment = 'root' | 'nodes'
 
 /**
  * The MindElixir instance
@@ -128,7 +128,7 @@ export interface MindElixirInstance extends MindElixirMethods {
   selection: SelectionArea
   selectionContainer?: string | HTMLElement
 
-  alignment: Aligment
+  alignment: Alignment
 }
 type PathString = string
 /**
@@ -156,7 +156,7 @@ export type Options = {
   theme?: Theme
   nodeMenu?: boolean
   selectionContainer?: string | HTMLElement
-  alignment?: Aligment
+  alignment?: Alignment
 }
 
 export type Uid = string


### PR DESCRIPTION
Previously, the toCenter method was based on centering relative to the me-root node. Now, a new optional parameter, alignment, has been added when initializing MindElixir. By default, its value is 'root', meaning it still centers based on the me-root node. However, it can be set to 'nodes', in which case the entire mind map will be centered.

