### PR TITLE
fix: Make the fullscreen button exit fullscreen when fullscreen

### DIFF
--- a/src/plugin/toolBar.ts
+++ b/src/plugin/toolBar.ts
@@ -25,7 +25,11 @@ function createToolBarRBContainer(mind: MindElixirInstance) {
   // toolBarRBContainer.appendChild(percentage)
   toolBarRBContainer.className = 'mind-elixir-toolbar rb'
   fc.onclick = () => {
-    mind.el.requestFullscreen()
+    if (!document.fullscreenElement) {
+      mind.el.requestFullscreen();
+    } else {
+      document.exitFullscreen();
+    }
   }
   gc.onclick = () => {
     mind.toCenter()

--- a/src/plugin/toolBar.ts
+++ b/src/plugin/toolBar.ts
@@ -25,10 +25,10 @@ function createToolBarRBContainer(mind: MindElixirInstance) {
   // toolBarRBContainer.appendChild(percentage)
   toolBarRBContainer.className = 'mind-elixir-toolbar rb'
   fc.onclick = () => {
-    if (!document.fullscreenElement) {
-      mind.el.requestFullscreen();
+    if (document.fullscreenElement === mind.el) {
+      document.exitFullscreen()
     } else {
-      document.exitFullscreen();
+      mind.el.requestFullscreen()
     }
   }
   gc.onclick = () => {


### PR DESCRIPTION
Before:
Cannot exit fullscreen with this button; only entering fullscreen is possible.

After:
Make the fullscreen button exit fullscreen when fullscreen