### PR TITLE
chore(ci): add dependents action

### DIFF
--- a/.github/workflows/dependents.yml
+++ b/.github/workflows/dependents.yml
@@ -1,0 +1,16 @@
+name: Dependents Action
+
+on:
+  push:
+    branches: [master]
+  schedule:
+    - cron: "0 0 1 * *"
+  workflow_dispatch:
+
+jobs:
+  dependents:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: gouravkhunger/dependents.info@main

--- a/readme.md
+++ b/readme.md
@@ -18,6 +18,9 @@
   <a href="https://bundlephobia.com/result?p=mind-elixir">
     <img src="https://badgen.net/bundlephobia/dependency-count/mind-elixir" alt="dependency-count">
   </a>
+  <a href="https://dependents.info/SSShooter/mind-elixir-core">
+    <img src="https://dependents.info/SSShooter/mind-elixir-core/badge" />
+  </a>
   <a href="https://packagephobia.com/result?p=mind-elixir">
     <img src="https://packagephobia.com/badge?p=mind-elixir" alt="package size">
   </a>
@@ -51,6 +54,7 @@ Features:
 <details>
 <summary>Table of Contents</summary>
 
+- [Used by](#used-by)
 - [Try now](#try-now)
   - [Playground](#playground)
 - [Documentation](#documentation)
@@ -74,6 +78,12 @@ Features:
 - [Contributors](#contributors)
 
 </details>
+
+## Used by
+
+<a href="https://dependents.info/SSShooter/mind-elixir-core">
+  <img src="https://dependents.info/SSShooter/mind-elixir-core/image.svg" />
+</a>
 
 ## Try now
 


### PR DESCRIPTION
Hi there!

Thank you for this awesome project! This PR adds a beautiful "Used by" section in the `README.md` file to showcase it's impact.

I've created this using an [open source](https://github.com/gouravkhunger/dependents.info) tool I built myself: [dependents.info](https://dependents.info). Here's a preview of how the image renders:

## Used by

![github network dependents image generated by dependents.info](https://dependents.info/gouravkhunger/jekyll-auto-authors/image.svg)

There's also a shield.io based badge if you prefer the smaller variant.

![github network dependents total count generated by dependents.info](https://dependents.info/gouravkhunger/jekyll-auto-authors/badge)

Please feel free to close the PR if you don't want to have this!