### PR TITLE
Add selectionDisabled param to allow better experience on mobile

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -38,6 +38,7 @@ function MindElixir(
     theme,
     alignment,
     scaleSensitivity,
+    selectionDisabled,
   }: Options
 ): void {
   let ele: HTMLElement | null = null
@@ -79,6 +80,7 @@ function MindElixir(
 
   this.container = $d.createElement('div') // map container
   this.selectionContainer = selectionContainer || this.container
+  this.selectionDisabled = selectionDisabled || false
 
   this.container.className = 'map-container'
 

--- a/src/methods.ts
+++ b/src/methods.ts
@@ -86,7 +86,7 @@ const methods = {
     if (import.meta.env.MODE !== 'lite') {
       this.keypress && keypressInit(this, this.keypress)
 
-      if (this.editable) {
+      if (this.editable && !this.selectionDisabled) {
         selection(this)
       }
       if (this.contextMenu) {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -138,6 +138,7 @@ export interface Options {
   selectionContainer?: string | HTMLElement
   alignment?: Alignment
   scaleSensitivity?: number
+  selectionDisabled?: boolean
 }
 
 export type Uid = string


### PR DESCRIPTION
When using touch screens, the selection rectangle gets in the way of moving the map. This will allow users to decide if they want to allow this selection to happen if they are using touch screens ( such as mobile phones) to improve the usability of the map.