### PR TITLE
fix: call e.preventDefault() in undo/redo key handler

### DIFF
--- a/src/plugin/operationHistory.ts
+++ b/src/plugin/operationHistory.ts
@@ -106,8 +106,13 @@ export default function (mei: MindElixirInstance) {
   }
   const handleKeyDown = function (e: KeyboardEvent) {
     // console.log(`mei.map.addEventListener('keydown', handleKeyDown)`, e.key, history.length, currentIndex)
-    if ((e.metaKey || e.ctrlKey) && ((e.shiftKey && e.key === 'Z') || e.key === 'y')) mei.redo()
-    else if ((e.metaKey || e.ctrlKey) && e.key === 'z') mei.undo()
+    if ((e.metaKey || e.ctrlKey) && ((e.shiftKey && e.key === 'Z') || e.key === 'y')) {
+      mei.redo()
+      e.preventDefault()
+    } else if ((e.metaKey || e.ctrlKey) && e.key === 'z') {
+      mei.undo()
+      e.preventDefault()
+    }
   }
   const handleSelectNodes = function () {
     currentSelectedNodes = mei.currentNodes.map(n => n.nodeObj)


### PR DESCRIPTION
## Problem

When MindElixir is embedded in a webview-based host (e.g. VS Code extension, Visual Studio WebView2), pressing `Ctrl+Z` / `Ctrl+Y` fires **both** MindElixir's undo/redo logic **and** the browser's native undo action on any focused `contenteditable` element (such as an open node label editor).

This causes corrupted state — the node text editor may undo independently while MindElixir's history also steps back, producing inconsistent results.

## Fix

Call `e.preventDefault()` in `handleKeyDown` after invoking `mei.undo()` / `mei.redo()`, so the browser's default undo/redo action is suppressed and only MindElixir's own history logic runs.

```ts
const handleKeyDown = function (e: KeyboardEvent) {
  if ((e.metaKey || e.ctrlKey) && ((e.shiftKey && e.key === 'Z') || e.key === 'y')) {
    mei.redo()
    e.preventDefault()
  } else if ((e.metaKey || e.ctrlKey) && e.key === 'z') {
    mei.undo()
    e.preventDefault()
  }
}
```

This is consistent with how other rich editors handle keyboard shortcuts that override browser defaults.