### PR TITLE
feat: expose clearHistory() to reset the undo/redo stack

### DIFF
--- a/src/plugin/operationHistory.ts
+++ b/src/plugin/operationHistory.ts
@@ -88,6 +88,11 @@ export default function (mei: MindElixirInstance) {
       }
     }
   }
+  mei.clearHistory = function () {
+    history = []
+    currentIndex = -1
+    current = mei.getData()
+  }
   const handleOperation = function (operation: Operation) {
     if (operation.name === 'beginEdit') return
     history = history.slice(0, currentIndex + 1)

--- a/src/plugin/operationHistory.ts
+++ b/src/plugin/operationHistory.ts
@@ -92,6 +92,7 @@ export default function (mei: MindElixirInstance) {
     history = []
     currentIndex = -1
     current = mei.getData()
+    currentSelectedNodes = []
   }
   const handleOperation = function (operation: Operation) {
     if (operation.name === 'beginEdit') return

--- a/src/plugin/operationHistory.ts
+++ b/src/plugin/operationHistory.ts
@@ -92,7 +92,7 @@ export default function (mei: MindElixirInstance) {
     history = []
     currentIndex = -1
     current = mei.getData()
-    currentSelectedNodes = []
+    mei.clearSelection()
   }
   const handleOperation = function (operation: Operation) {
     if (operation.name === 'beginEdit') return

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -121,6 +121,13 @@ export interface MindElixirInstance extends Omit<Required<Options>, 'markdown' |
   history: Operation[]
   undo: () => void
   redo: () => void
+  /**
+   * Reset the undo/redo stack and update the internal baseline snapshot to the
+   * current diagram state. Call this after loading new data into an existing
+   * instance (e.g. after `refresh()`) to prevent users from undoing back into
+   * a previously loaded diagram.
+   */
+  clearHistory: () => void
 
   selection: SelectionArea
   dragMoveHelper: ReturnType<typeof createDragMoveHelper>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -126,8 +126,10 @@ export interface MindElixirInstance extends Omit<Required<Options>, 'markdown' |
    * current diagram state. Call this after loading new data into an existing
    * instance (e.g. after `refresh()`) to prevent users from undoing back into
    * a previously loaded diagram.
+   *
+   * Only available when `allowUndo` is `true` (the default).
    */
-  clearHistory: () => void
+  clearHistory?: () => void
 
   selection: SelectionArea
   dragMoveHelper: ReturnType<typeof createDragMoveHelper>

--- a/tests/clear-history.spec.ts
+++ b/tests/clear-history.spec.ts
@@ -1,0 +1,107 @@
+import { test, expect } from './mind-elixir-test'
+
+const diagramA = {
+  nodeData: {
+    id: 'root-a',
+    topic: 'Diagram A',
+    children: [
+      { id: 'child-a', topic: 'Child A' },
+    ],
+  },
+}
+
+const diagramB = {
+  nodeData: {
+    id: 'root-b',
+    topic: 'Diagram B',
+    children: [
+      { id: 'child-b', topic: 'Child B' },
+    ],
+  },
+}
+
+test.beforeEach(async ({ me }) => {
+  await me.init(diagramA)
+})
+
+test('clearHistory - undo cannot revert into the pre-refresh diagram', async ({ page, me }) => {
+  // Perform an operation in Diagram A
+  await me.click('Child A')
+  await page.keyboard.press('Tab')
+  await page.keyboard.press('Enter')
+  await expect(me.getByText('New Node')).toBeVisible()
+
+  // Load a new diagram and clear the history
+  await page.evaluate(data => {
+    const mind = (window as any)['#map']
+    mind.refresh(data)
+    mind.clearHistory()
+  }, diagramB)
+
+  // Diagram B should now be shown
+  await expect(me.getByText('Diagram B')).toBeVisible()
+  await expect(me.getByText('Diagram A')).toBeHidden()
+
+  // Undo should NOT travel back into Diagram A
+  await page.keyboard.press('Control+z')
+  await expect(me.getByText('Diagram B')).toBeVisible()
+  await expect(me.getByText('Diagram A')).toBeHidden()
+
+  // Redo should also be a no-op
+  await page.keyboard.press('Control+y')
+  await expect(me.getByText('Diagram B')).toBeVisible()
+  await expect(me.getByText('Diagram A')).toBeHidden()
+})
+
+test('clearHistory - operations after clearHistory are undoable normally', async ({ page, me }) => {
+  // Perform an operation in Diagram A then load Diagram B and clear history
+  await me.click('Child A')
+  await page.keyboard.press('Delete')
+  await expect(me.getByText('Child A')).toBeHidden()
+
+  await page.evaluate(data => {
+    const mind = (window as any)['#map']
+    mind.refresh(data)
+    mind.clearHistory()
+  }, diagramB)
+
+  // Now add a node to Diagram B
+  await me.click('Child B')
+  await page.keyboard.press('Tab')
+  await page.keyboard.press('Enter')
+  await expect(me.getByText('New Node')).toBeVisible()
+
+  // Undo the add — should work
+  await page.keyboard.press('Control+z')
+  await expect(me.getByText('New Node')).toBeHidden()
+
+  // Redo the add — should also work
+  await page.keyboard.press('Control+y')
+  await expect(me.getByText('New Node')).toBeVisible()
+
+  // One more undo should be a no-op (no history before the cleared point)
+  await page.keyboard.press('Control+z') // undo add
+  await page.keyboard.press('Control+z') // should be no-op, not reach Diagram A
+  await expect(me.getByText('Diagram B')).toBeVisible()
+  await expect(me.getByText('Diagram A')).toBeHidden()
+})
+
+test('clearHistory - first undo baseline is the refreshed diagram state', async ({ page, me }) => {
+  // Load Diagram B, clear history, then add a node and undo
+  await page.evaluate(data => {
+    const mind = (window as any)['#map']
+    mind.refresh(data)
+    mind.clearHistory()
+  }, diagramB)
+
+  await me.click('Child B')
+  await page.keyboard.press('Tab')
+  await page.keyboard.press('Enter')
+  await expect(me.getByText('New Node')).toBeVisible()
+
+  // Undo restores exactly to the state right after refresh (Diagram B with just Child B)
+  await page.keyboard.press('Control+z')
+  await expect(me.getByText('New Node')).toBeHidden()
+  await expect(me.getByText('Child B')).toBeVisible()
+  await expect(me.getByText('Diagram B')).toBeVisible()
+})

--- a/tests/clear-history.spec.ts
+++ b/tests/clear-history.spec.ts
@@ -4,9 +4,7 @@ const diagramA = {
   nodeData: {
     id: 'root-a',
     topic: 'Diagram A',
-    children: [
-      { id: 'child-a', topic: 'Child A' },
-    ],
+    children: [{ id: 'child-a', topic: 'Child A' }],
   },
 }
 
@@ -14,9 +12,7 @@ const diagramB = {
   nodeData: {
     id: 'root-b',
     topic: 'Diagram B',
-    children: [
-      { id: 'child-b', topic: 'Child B' },
-    ],
+    children: [{ id: 'child-b', topic: 'Child B' }],
   },
 }
 
@@ -24,25 +20,24 @@ test.beforeEach(async ({ me }) => {
   await me.init(diagramA)
 })
 
-test('clearHistory - undo cannot revert into the pre-refresh diagram', async ({ page, me }) => {
+test('clearHistory - undo cannot revert into pre-refresh diagram', async ({ page, me }) => {
   // Perform an operation in Diagram A
   await me.click('Child A')
   await page.keyboard.press('Tab')
   await page.keyboard.press('Enter')
   await expect(me.getByText('New Node')).toBeVisible()
 
-  // Load a new diagram and clear the history
-  await page.evaluate(data => {
+  // Load Diagram B and clear the history stack
+  await page.evaluate((data: typeof diagramB) => {
     const mind = (window as any)['#map']
     mind.refresh(data)
     mind.clearHistory()
   }, diagramB)
 
-  // Diagram B should now be shown
   await expect(me.getByText('Diagram B')).toBeVisible()
   await expect(me.getByText('Diagram A')).toBeHidden()
 
-  // Undo should NOT travel back into Diagram A
+  // Undo should be a no-op — must not travel back into Diagram A
   await page.keyboard.press('Control+z')
   await expect(me.getByText('Diagram B')).toBeVisible()
   await expect(me.getByText('Diagram A')).toBeHidden()
@@ -54,18 +49,20 @@ test('clearHistory - undo cannot revert into the pre-refresh diagram', async ({ 
 })
 
 test('clearHistory - operations after clearHistory are undoable normally', async ({ page, me }) => {
-  // Perform an operation in Diagram A then load Diagram B and clear history
+  // Perform an operation in Diagram A, then switch to Diagram B and clear history
   await me.click('Child A')
   await page.keyboard.press('Delete')
   await expect(me.getByText('Child A')).toBeHidden()
 
-  await page.evaluate(data => {
+  await page.evaluate((data: typeof diagramB) => {
     const mind = (window as any)['#map']
     mind.refresh(data)
     mind.clearHistory()
   }, diagramB)
 
-  // Now add a node to Diagram B
+  await expect(me.getByText('Diagram B')).toBeVisible()
+
+  // Add a node to Diagram B
   await me.click('Child B')
   await page.keyboard.press('Tab')
   await page.keyboard.press('Enter')
@@ -74,32 +71,33 @@ test('clearHistory - operations after clearHistory are undoable normally', async
   // Undo the add — should work
   await page.keyboard.press('Control+z')
   await expect(me.getByText('New Node')).toBeHidden()
+  await expect(me.getByText('Diagram B')).toBeVisible()
 
-  // Redo the add — should also work
-  await page.keyboard.press('Control+y')
-  await expect(me.getByText('New Node')).toBeVisible()
-
-  // One more undo should be a no-op (no history before the cleared point)
-  await page.keyboard.press('Control+z') // undo add
-  await page.keyboard.press('Control+z') // should be no-op, not reach Diagram A
+  // Another undo should be a no-op — must not reach Diagram A
+  await page.keyboard.press('Control+z')
   await expect(me.getByText('Diagram B')).toBeVisible()
   await expect(me.getByText('Diagram A')).toBeHidden()
+
+  // Redo restores the added node
+  await page.keyboard.press('Control+y')
+  await expect(me.getByText('New Node')).toBeVisible()
 })
 
 test('clearHistory - first undo baseline is the refreshed diagram state', async ({ page, me }) => {
-  // Load Diagram B, clear history, then add a node and undo
-  await page.evaluate(data => {
+  // Switch to Diagram B and clear history
+  await page.evaluate((data: typeof diagramB) => {
     const mind = (window as any)['#map']
     mind.refresh(data)
     mind.clearHistory()
   }, diagramB)
 
+  // Add a node to Diagram B
   await me.click('Child B')
   await page.keyboard.press('Tab')
   await page.keyboard.press('Enter')
   await expect(me.getByText('New Node')).toBeVisible()
 
-  // Undo restores exactly to the state right after refresh (Diagram B with just Child B)
+  // Undo should restore exactly to the post-refresh state of Diagram B
   await page.keyboard.press('Control+z')
   await expect(me.getByText('New Node')).toBeHidden()
   await expect(me.getByText('Child B')).toBeVisible()


### PR DESCRIPTION
## Motivation

When an application loads new data into an existing MindElixir instance via `refresh()`, the internal undo/redo history still contains snapshots from the previous diagram. This lets users press Ctrl+Z and silently travel back into an earlier diagram's state — a confusing and data-loss-prone experience.

A host needs a way to discard that stale history after loading new data.

## Changes

### `src/plugin/operationHistory.ts`
Adds `mei.clearHistory()`, which:
- clears the `history` array
- resets `currentIndex` to `-1`
- re-captures `current` from `mei.getData()` so the fresh snapshot is the new undo baseline

### `src/types/index.ts`
Declares `clearHistory: () => void` on `MindElixirInstance` with a JSDoc comment explaining its purpose.

## Usage

```ts
mind.refresh(newData)
mind.clearHistory() // users can no longer undo back into the previous diagram
```