### PR TITLE
Refactor: zooming the mind-map viewport on the trackpad

### DIFF
--- a/src/mouse.ts
+++ b/src/mouse.ts
@@ -1,4 +1,3 @@
-import { handleZoom } from './plugin/keypress'
 import {
   createNodeDragState,
   handleNodeDragStart,
@@ -7,6 +6,7 @@ import {
   handleNodeDragCancel,
   updateGhostPosition,
 } from './plugin/nodeDraggable'
+import { handleWheelZoom } from './plugin/keypress'
 import type { SummarySvgGroup } from './summary'
 import type { Expander, CustomSvg, Topic } from './types/dom'
 import type { MindElixirInstance } from './types/index'
@@ -389,14 +389,9 @@ export default function (mind: MindElixirInstance) {
   const handleWheel = (e: WheelEvent) => {
     e.stopPropagation()
     e.preventDefault()
-    if (e.ctrlKey || e.metaKey) {
-      if (e.deltaY < 0) handleZoom(mind, 'in', mind.dragMoveHelper)
-      else if (mind.scaleVal - mind.scaleSensitivity > 0) handleZoom(mind, 'out', mind.dragMoveHelper)
-    } else if (e.shiftKey) {
-      mind.move(-e.deltaY, 0)
-    } else {
-      mind.move(-e.deltaX, -e.deltaY)
-    }
+    if (e.ctrlKey || e.metaKey) return handleWheelZoom(mind, e)
+    if (e.shiftKey) return mind.move(-e.deltaY, 0)
+    mind.move(-e.deltaX, -e.deltaY)
   }
 
   const { container } = mind

--- a/src/plugin/keypress.ts
+++ b/src/plugin/keypress.ts
@@ -5,6 +5,37 @@ import { DirectionClass } from '../types/index'
 import { setExpand, unionTopics } from '../utils'
 
 const COPY_MAGIC = 'MIND-ELIXIR-WAIT-COPY'
+const WHEEL_ZOOM_LINE_HEIGHT = 40
+const WHEEL_ZOOM_PIXEL_STEP = 10
+
+type ZoomOffset = {
+  x: number
+  y: number
+}
+
+type WheelZoomStepInput = {
+  deltaMode: number
+  deltaY: number
+  scaleSensitivity: number
+  viewportHeight: number
+}
+
+export const normalizeWheelDelta = ({ deltaMode, deltaY, viewportHeight }: Omit<WheelZoomStepInput, 'scaleSensitivity'>) => {
+  if (deltaMode === WheelEvent.DOM_DELTA_LINE) return deltaY * WHEEL_ZOOM_LINE_HEIGHT
+  if (deltaMode === WheelEvent.DOM_DELTA_PAGE) return deltaY * viewportHeight
+  return deltaY
+}
+
+export const getWheelZoomScaleDelta = ({ deltaMode, deltaY, scaleSensitivity, viewportHeight }: WheelZoomStepInput) => {
+  const normalizedDelta = normalizeWheelDelta({ deltaMode, deltaY, viewportHeight })
+  const rawScaleDelta = (-normalizedDelta / WHEEL_ZOOM_PIXEL_STEP) * scaleSensitivity
+  return Math.max(-scaleSensitivity, Math.min(scaleSensitivity, rawScaleDelta))
+}
+
+const applyScaleDelta = (mei: MindElixirInstance, scaleDelta: number, offset?: ZoomOffset) => {
+  if (scaleDelta === 0) return
+  mei.scale(mei.scaleVal + scaleDelta, offset)
+}
 
 const selectRootSide = (mei: MindElixirInstance, direction: DirectionClass) => {
   const tpcs = mei.map.querySelectorAll(`.${direction}>me-wrapper>me-parent>me-tpc`)
@@ -59,22 +90,23 @@ const handlePrevNext = function (mei: MindElixirInstance, direction: 'previous' 
     mei.selectNode(current)
   }
 }
-export const handleZoom = function (
-  mei: MindElixirInstance,
-  direction: 'in' | 'out',
-  offset?: {
-    x: number
-    y: number
-  }
-) {
-  const { scaleVal, scaleSensitivity } = mei
-  switch (direction) {
-    case 'in':
-      mei.scale(scaleVal + scaleSensitivity, offset)
-      break
-    case 'out':
-      mei.scale(scaleVal - scaleSensitivity, offset)
-  }
+export const handleZoom = function (mei: MindElixirInstance, direction: 'in' | 'out', offset?: ZoomOffset) {
+  const scaleDelta = direction === 'in' ? mei.scaleSensitivity : -mei.scaleSensitivity
+  applyScaleDelta(mei, scaleDelta, offset)
+}
+
+export const handleWheelZoom = (mei: MindElixirInstance, e: WheelEvent) => {
+  const scaleDelta = getWheelZoomScaleDelta({
+    deltaMode: e.deltaMode,
+    deltaY: e.deltaY,
+    scaleSensitivity: mei.scaleSensitivity,
+    viewportHeight: mei.container.clientHeight || window.innerHeight,
+  })
+
+  applyScaleDelta(mei, scaleDelta, {
+    x: e.clientX,
+    y: e.clientY,
+  })
 }
 
 export default function (mind: MindElixirInstance, options: boolean | KeypressOptions) {

--- a/src/plugin/keypress.ts
+++ b/src/plugin/keypress.ts
@@ -90,7 +90,7 @@ const handlePrevNext = function (mei: MindElixirInstance, direction: 'previous' 
     mei.selectNode(current)
   }
 }
-export const handleZoom = function (mei: MindElixirInstance, direction: 'in' | 'out', offset?: ZoomOffset) {
+export const handleKeypressZoom = function (mei: MindElixirInstance, direction: 'in' | 'out', offset?: ZoomOffset) {
   const scaleDelta = direction === 'in' ? mei.scaleSensitivity : -mei.scaleSensitivity
   applyScaleDelta(mei, scaleDelta, offset)
 }
@@ -103,10 +103,7 @@ export const handleWheelZoom = (mei: MindElixirInstance, e: WheelEvent) => {
     viewportHeight: mei.container.clientHeight || window.innerHeight,
   })
 
-  applyScaleDelta(mei, scaleDelta, {
-    x: e.clientX,
-    y: e.clientY,
-  })
+  applyScaleDelta(mei, scaleDelta, { x: e.clientX, y: e.clientY })
 }
 
 export default function (mind: MindElixirInstance, options: boolean | KeypressOptions) {
@@ -213,12 +210,12 @@ export default function (mind: MindElixirInstance, options: boolean | KeypressOp
     },
     '=': (e: KeyboardEvent) => {
       if (e.metaKey || e.ctrlKey) {
-        handleZoom(mind, 'in')
+        handleKeypressZoom(mind, 'in')
       }
     },
     '-': (e: KeyboardEvent) => {
       if (e.metaKey || e.ctrlKey) {
-        handleZoom(mind, 'out')
+        handleKeypressZoom(mind, 'out')
       }
     },
     '0': (e: KeyboardEvent) => {


### PR DESCRIPTION
# 背景

提交此PR 的背景是： 我在使用mac 触控板进行缩放操作 mind-map  时，缩放的倍率不是线性的。
轻微的双指放大操作， mind-map  就会放大特别多，使用体验不太好。

# 旧实现的局限在于

在 Mac 触控板上 pinch 缩放时，Chrome 会连续发出很多 wheel 事件，而且这些事件通常是：
- deltaMode = 0，也就是像素单位
- 每次 deltaY 很小
- 但事件频率很高

那就意味着：不管这次事件有多小，只要来了一个事件，就直接加/减一整份 scaleSensitivity，假设 scaleSensitivity = 0.1，那一次轻微 pinch 过程中如果来了 10 个小事件，就可能直接跳 1.0 -> 2.0 这种量级，体感会觉得“太快”，没有线性变化


# 新策略的实现

按事件次数驱动”改成了“按事件强度驱动”，把deltaY 换算成缩放强度，按 deltaY 大小来做连续步进。这样就可以在触控板操作时，实现跟手的缩放强度。